### PR TITLE
Fix margins of custom choreography font

### DIFF
--- a/font/include/css/choreography-embedded.css
+++ b/font/include/css/choreography-embedded.css
@@ -31,7 +31,6 @@
   display: inline-block;
   text-decoration: inherit;
   width: 1em;
-  margin-right: .2em;
   text-align: center;
   /* opacity: .8; */
  
@@ -41,10 +40,6 @@
      
   /* fix buttons height, for twitter bootstrap */
   line-height: 1em;
- 
-  /* Animation center compensation - margins should be symmetric */
-  /* remove if not needed */
-  margin-left: .2em;
  
   /* you can be more comfortable with increased icons size */
   /* font-size: 120%; */

--- a/font/include/css/choreography.css
+++ b/font/include/css/choreography.css
@@ -29,7 +29,6 @@
   display: inline-block;
   text-decoration: inherit;
   width: 1em;
-  margin-right: .2em;
   text-align: center;
   /* opacity: .8; */
  
@@ -39,10 +38,6 @@
  
   /* fix buttons height, for twitter bootstrap */
   line-height: 1em;
- 
-  /* Animation center compensation - margins should be symmetric */
-  /* remove if not needed */
-  margin-left: .2em;
  
   /* you can be more comfortable with increased icons size */
   /* font-size: 120%; */


### PR DESCRIPTION
The symbols had a weird margin in the CSS which made them clip out of bounds sometimes.