### PR TITLE
Fix DI linking when importing participants

### DIFF
--- a/lib/import/ChoreoImporter.js
+++ b/lib/import/ChoreoImporter.js
@@ -102,7 +102,7 @@ ChoreoImporter.prototype.add = function(semantic, parentElement) {
      * be multiple bands for the same semantic object (i.e., a bpmn:Participant).
      * For that reason, we have to iterate through all band DIs and find the right one.
      */
-    di = semantic.di.$parent.planeElement.find(
+    di = parentElement.businessObject.di.$parent.planeElement.find(
       diBand => diBand.choreographyActivityShape === parentElement.businessObject.di && diBand.bpmnElement === semantic
     );
   } else {

--- a/lib/import/ChoreoTreeWalker.js
+++ b/lib/import/ChoreoTreeWalker.js
@@ -102,16 +102,19 @@ export default function ChoreoTreeWalker(handler, translate) {
     var bpmnElement = di.bpmnElement;
 
     if (bpmnElement) {
-      if (bpmnElement.di) {
-        logError(
-          translate('multiple DI elements defined for {element}', {
-            element: elementToString(bpmnElement)
-          }),
-          { element: bpmnElement }
-        );
-      } else {
-        diRefs.bind(bpmnElement, 'di');
-        bpmnElement.di = di;
+      // do not link DIs for participants because they have more than one
+      if (!is(bpmnElement, 'bpmn:Participant')) {
+        if (bpmnElement.di) {
+          logError(
+            translate('multiple DI elements defined for {element}', {
+              element: elementToString(bpmnElement)
+            }),
+            { element: bpmnElement }
+          );
+        } else {
+          diRefs.bind(bpmnElement, 'di');
+          bpmnElement.di = di;
+        }
       }
     } else {
       logError(

--- a/test/spec/ChoreoModelerSpec.js
+++ b/test/spec/ChoreoModelerSpec.js
@@ -45,7 +45,7 @@ describe('choreo modeler', function() {
 
   describe('choreo import', function() {
 
-    it.skip('should have no warnings on import of choreo with multiplicities', function(done) {
+    it('should have no warnings on import of choreo with multiplicities', function(done) {
       createModeler(choreoWithMultiplicities, function(modeler, elemReg, err, warnings) {
         expect(warnings).to.be.empty;
         done();
@@ -59,7 +59,7 @@ describe('choreo modeler', function() {
       });
     });
 
-    it.skip('should have no warnings on import of choreo with loops', function(done) {
+    it('should have no warnings on import of choreo with loops', function(done) {
       createModeler(choreoWithLoops, function(modeler, elemReg, err, warnings) {
         expect(warnings).to.be.empty;
         done();


### PR DESCRIPTION
Resolves #29.

Suppresses warnings when importing participants because they can have multiple DIs. The previous logic did not take this into account.