### PR TITLE
Update participant band labels

### DIFF
--- a/lib/features/ChoreoUpdater.js
+++ b/lib/features/ChoreoUpdater.js
@@ -15,10 +15,9 @@ import {
  * A handler responsible for updating the choreography shapes and business objects.
  */
 export default function ChoreoUpdater(
-    eventBus, bpmnFactory, connectionDocking,
-    translate) {
+    eventBus, elementRegistry, injector) {
 
-  BpmnUpdater.call(this, eventBus, bpmnFactory, connectionDocking, translate);
+  injector.invoke(BpmnUpdater, this);
 
   function updateChoreographyActivities(e) {
     //TODO do some specific updating for choreography activities
@@ -72,9 +71,8 @@ inherits(ChoreoUpdater, BpmnUpdater);
 
 ChoreoUpdater.$inject = [
   'eventBus',
-  'bpmnFactory',
-  'connectionDocking',
-  'translate'
+  'elementRegistry',
+  'injector'
 ];
 
 ChoreoUpdater.prototype.updateParent = function(element, oldParent) {

--- a/lib/features/behavior/CreateChoreoTaskBehavior.js
+++ b/lib/features/behavior/CreateChoreoTaskBehavior.js
@@ -18,9 +18,9 @@ import {
 /**
  * Behavior when creating a choreography task.
  */
-export default function CreateChoreoTaskBehavior(eventBus, bpmnFactory, canvas, elementFactory, create) {
+export default function CreateChoreoTaskBehavior(injector, bpmnFactory, canvas, elementFactory, create) {
 
-  CommandInterceptor.call(this, eventBus);
+  injector.invoke(CommandInterceptor, this);
 
   this.preExecute('shape.create', function(event) {
 
@@ -116,7 +116,7 @@ export default function CreateChoreoTaskBehavior(eventBus, bpmnFactory, canvas, 
 }
 
 CreateChoreoTaskBehavior.$inject = [
-  'eventBus',
+  'injector',
   'bpmnFactory',
   'canvas',
   'elementFactory',

--- a/lib/features/behavior/UpdateParticipantNameBehavior.js
+++ b/lib/features/behavior/UpdateParticipantNameBehavior.js
@@ -1,0 +1,56 @@
+import inherits from 'inherits';
+
+import {
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+/**
+ * Command interceptor used to update all participant bands of a specific participant
+ * when updating their name/label.
+ */
+export default function UpdateParticipantNameBehavior(injector, elementRegistry, eventBus) {
+
+  injector.invoke(CommandInterceptor, this);
+
+  this.preExecute('element.updateLabel', function(event) {
+    // replace all line breaks in the new name, we only want single line
+    console.log(event);
+    let context = event.context;
+    context.newLabel = context.newLabel.replace(/(?:\r\n|\r|\n)/g, '');
+  });
+
+  this.postExecute('element.updateLabel', function(event) {
+    let context = event.context;
+    let shape = context.element;
+    if (is(shape, 'bpmn:Participant')) {
+      updateAllBands(shape.businessObject, shape);
+    }
+  });
+
+  this.reverted('element.updateLabel', function(event) {
+    let context = event.context;
+    let shape = context.element;
+    if (is(shape, 'bpmn:Participant')) {
+      updateAllBands(shape.businessObject, shape);
+    }
+  });
+
+  function updateAllBands(participant, except) {
+    let bandShapes = elementRegistry.filter((element, gfx) => element != except && element.businessObject === participant);
+    bandShapes.forEach(bandShape => {
+      eventBus.fire('element.changed', {
+        element: bandShape
+      });
+    });
+  }
+}
+
+inherits(UpdateParticipantNameBehavior, CommandInterceptor);
+
+UpdateParticipantNameBehavior.$inject = [
+  'injector',
+  'elementRegistry',
+  'eventBus'
+];

--- a/lib/features/behavior/UpdateParticipantNameBehavior.js
+++ b/lib/features/behavior/UpdateParticipantNameBehavior.js
@@ -16,7 +16,6 @@ export default function UpdateParticipantNameBehavior(injector, elementRegistry,
 
   this.preExecute('element.updateLabel', function(event) {
     // replace all line breaks in the new name, we only want single line
-    console.log(event);
     let context = event.context;
     context.newLabel = context.newLabel.replace(/(?:\r\n|\r|\n)/g, '');
   });

--- a/lib/features/behavior/index.js
+++ b/lib/features/behavior/index.js
@@ -1,8 +1,11 @@
 import CreateChoreoTaskBehavior from './CreateChoreoTaskBehavior';
+import UpdateParticipantNameBehavior from './UpdateParticipantNameBehavior';
 
 export default {
   __init__: [
-    'createChoreoTaskBehavior'
+    'createChoreoTaskBehavior',
+    'updateParticipantNameBehavior'
   ],
-  createChoreoTaskBehavior: [ 'type', CreateChoreoTaskBehavior ]
+  createChoreoTaskBehavior: [ 'type', CreateChoreoTaskBehavior ],
+  updateParticipantNameBehavior: [ 'type', UpdateParticipantNameBehavior ]
 };

--- a/lib/features/cmd/CreateParticipantBandHandler.js
+++ b/lib/features/cmd/CreateParticipantBandHandler.js
@@ -137,9 +137,13 @@ CreateParticipantBandHandler.prototype.createBand = function(context) {
     }
 
     // create band shape
-    let diBand = this._bpmnFactory.create('bpmndi:BPMNShape', {
+    let diBand = this._bpmnFactory.createDiShape(participant, {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0
+    }, {
       choreographyActivityShape: activity.di,
-      bpmnElement: participant,
       id: idGenerator.next()
     });
     bandShape = this._elementFactory.createShape({


### PR DESCRIPTION
This PR updates all the participant bands of a participant when changing the name/label on one band.

Also fixes a bug that prevented us from creating new participant bands sometimes.