### PR TITLE
Forbid moving of participant bands and messages

### DIFF
--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -5,6 +5,7 @@ import inherits from 'inherits';
 import CoreModule from './core';
 
 import ContextPadModule from './features/context-pad';
+import KeyboardMoveSelectionModule from './features/keyboard-move-selection';
 import LabelEditingModule from './features/label-editing';
 import ModelingModule from './features/modeling';
 import PaletteModule from './features/palette';
@@ -48,6 +49,7 @@ ChoreoModeler.prototype._modules = [].concat(
   ],
   [
     ContextPadModule,
+    KeyboardMoveSelectionModule,
     LabelEditingModule,
     ModelingModule,
     PaletteModule,

--- a/lib/features/keyboard-move-selection/ChoreoMoveSelection.js
+++ b/lib/features/keyboard-move-selection/ChoreoMoveSelection.js
@@ -1,0 +1,35 @@
+import inherits from 'inherits';
+
+import KeyboardMoveSelection from 'diagram-js/lib/features/keyboard-move-selection/KeyboardMoveSelection';
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+/**
+ * Override the KeyboardMoveSelection handler in diagram-js to prohibit moving
+ * participant bands or messages using arrow keys.
+ */
+export default function ChoreoMoveSelection(injector, selection) {
+  injector.invoke(KeyboardMoveSelection, this);
+
+  let oldMoveSelection = this.moveSelection;
+  this.moveSelection = function(direction, accelerated) {
+    var selectedElements = selection.get();
+
+    if (!selectedElements.length) {
+      return;
+    }
+
+    // participant bands and messages are not movable
+    let isNotMovable = function(shape) {
+      return is(shape, 'bpmn:Participant') || is(shape, 'bpmn:Message');
+    };
+    if (selectedElements.some(isNotMovable)) {
+      return;
+    }
+
+    oldMoveSelection.call(this, direction, accelerated);
+  };
+}
+
+inherits(ChoreoMoveSelection, KeyboardMoveSelection);
+
+ChoreoMoveSelection.$inject = [ 'injector', 'selection' ];

--- a/lib/features/keyboard-move-selection/index.js
+++ b/lib/features/keyboard-move-selection/index.js
@@ -1,0 +1,8 @@
+import ChoreoMoveSelection from './ChoreoMoveSelection';
+
+export default {
+  __init__: [
+    'keyboardMoveSelection'
+  ],
+  keyboardMoveSelection: [ 'type', ChoreoMoveSelection ]
+};

--- a/lib/features/rules/ChoreoRules.js
+++ b/lib/features/rules/ChoreoRules.js
@@ -221,6 +221,17 @@ ChoreoRules.prototype.init = function() {
   });
 };
 
+ChoreoRules.prototype.canMove = function(shapes, target) {
+  // participant bands and messages are not movable
+  let isNotMovable = function(shape) {
+    return is(shape, 'bpmn:Participant') || is(shape, 'bpmn:Message');
+  };
+  if (shapes.some(isNotMovable)) {
+    return false;
+  }
+  return BpmnRules.prototype.canMove.call(this, shapes, target);
+};
+
 ChoreoRules.prototype.canCreate = function(shape, target, source, position) {
   if (is(target, 'bpmn:Choreography')) {
     // elements can be created within a choreography


### PR DESCRIPTION
Resolves #58 and resolves #59 

This PR implements checks that forbid moving participant bands and messages both by dragging and keyboard.