### PR TITLE
Replace the attribute attachedMessageShape

### DIFF
--- a/lib/features/modeling/cmd/MakeInitiatingParticipantBandHandler.js
+++ b/lib/features/modeling/cmd/MakeInitiatingParticipantBandHandler.js
@@ -1,4 +1,5 @@
 import { assign } from 'min-dash';
+import { getAttachedMessageShape } from '../../../util/MessageUtil';
 
 /**
  * Command to change the initiating participant band of a choreography. Fires on 'band.makeInitiating'.
@@ -18,14 +19,14 @@ MakeInitiatingParticipantBandHandler.prototype._redraw = function(context) {
   this._eventBus.fire('element.changed', {
     element: context.initBandShape
   });
-  if (context.nonInitBandShape.attachedMessageShape) {
+  if (getAttachedMessageShape(context.nonInitBandShape)) {
     this._eventBus.fire('element.changed', {
-      element: context.nonInitBandShape.attachedMessageShape
+      element: getAttachedMessageShape(context.nonInitBandShape)
     });
   }
-  if (context.initBandShape.attachedMessageShape) {
+  if (getAttachedMessageShape(context.initBandShape)) {
     this._eventBus.fire('element.changed', {
-      element: context.initBandShape.attachedMessageShape
+      element: getAttachedMessageShape(context.initBandShape)
     });
   }
 };

--- a/lib/util/MessageUtil.js
+++ b/lib/util/MessageUtil.js
@@ -140,8 +140,16 @@ export function createMessageShape(injector, bandShape, messageFlow) {
   };
   assign(data, getAttachedMessageBounds(bandShape));
   let messageShape = elementFactory.createShape(data);
-  bandShape.attachedMessageShape = messageShape;
   return messageShape;
+}
+
+/**
+ * Get the attached message shape of a bandShape
+ * @param bandShape
+ * @returns {Array<Result>}
+ */
+export function getAttachedMessageShape(bandShape) {
+  return bandShape.children.find(m => is(m, 'bpmn:Message'));
 }
 
 /**


### PR DESCRIPTION
Add a function that finds the message shape of a band by searching the children of a bandShape. 
Thus, attachedMessageShape no longer has to be set manually. 