### PR TITLE
Fix SubChoreo "collapsedness" being switched on import

### DIFF
--- a/lib/import/ChoreoImporter.js
+++ b/lib/import/ChoreoImporter.js
@@ -188,7 +188,7 @@ ChoreoImporter.prototype.add = function(semantic, parentShape) {
       // elements that are displayed as shapes
       let collapsed = (
         is(semantic, 'bpmn:SubChoreography') || is(semantic, 'bpmn:CallChoreography')
-      ) ? (!!semantic.di.isExpanded) : false;
+      ) ? (!semantic.di.isExpanded) : false;
       let hidden = parentShape && (parentShape.hidden || parentShape.collapsed);
 
       // the bands of a collapsed choreo activity should still be visible


### PR DESCRIPTION
Fix an error where collapsed was not set correctly via isExpanded. This lead to collapsed SubChoreos being displayed as ExpandedSubChoreos and vice versa. Fixes #93