### PR TITLE
Fix hidden messages being shown on import

### DIFF
--- a/lib/features/modeling/behavior/ToggleChoreoCollapseBehavior.js
+++ b/lib/features/modeling/behavior/ToggleChoreoCollapseBehavior.js
@@ -171,7 +171,6 @@ function expandedBounds(shape, defaultSize) {
 
 function collapsedBounds(shape, defaultSize) {
   let newHeight = defaultSize.height + heightOfTopBands(shape) + heightOfBottomBands(shape);
-  console.log(shape, defaultSize, newHeight);
   return {
     x: shape.x + (shape.width - defaultSize.width) / 2,
     y: shape.y + (shape.height - newHeight) / 2,

--- a/lib/util/MessageUtil.js
+++ b/lib/util/MessageUtil.js
@@ -136,7 +136,7 @@ export function createMessageShape(injector, bandShape, messageFlow) {
   let data = {
     type: semantic.$type,
     businessObject: semantic,
-    hidden: !bandShape.diBand.isMessageVisible
+    hidden: bandShape.hidden || !bandShape.diBand.isMessageVisible
   };
   assign(data, getAttachedMessageBounds(bandShape));
   let messageShape = elementFactory.createShape(data);


### PR DESCRIPTION
When importing a collapsed sub-choreography, messages inside were previously shown despite the fact they should be hidden.